### PR TITLE
replace deprecated member of Foundry VTT API

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1187,8 +1187,8 @@ export class SWSEActorSheet extends ActorSheet {
                             html.find(".movable").each((i, item) => {
                                 let roll = new Roll(rollFormula).roll();
                                 let title = "";
-                                for(let part of roll.parts){
-                                    for(let result of part.results){
+                                for(let term of roll.terms){
+                                    for(let result of term.results){
                                         if(title !== "") {
                                             title += ", "
                                         }


### PR DESCRIPTION
Minor fix to address console.log warning when rolling character attributes.

Roll#parts is deprecated in favor of Roll#terms, as of Foundry VTT 0.7.0