### PR TITLE
Ataru lightsaber damage is not applying the correct Ability Modifier

### DIFF
--- a/module/actor/attack-handler.mjs
+++ b/module/actor/attack-handler.mjs
@@ -126,7 +126,7 @@ function isRanged(weapon) {
  * @param weapon {SWSEItem}
  * @returns {boolean}
  */
-function isLightsaber(weapon) {
+export function isLightsaber(weapon) {
     let itemData = weapon.system;
     return LIGHTSABER_WEAPON_TYPES.includes(itemData.subtype.toLowerCase());
 }

--- a/module/actor/attack-handler.mjs
+++ b/module/actor/attack-handler.mjs
@@ -3,6 +3,7 @@ import {SWSEItem} from "../item/item.mjs";
 import {Attack} from "./attack.mjs";
 import {compareSizes} from "./size.mjs";
 import {getInheritableAttribute} from "../attribute-helper.mjs";
+import { RANGED_WEAPON_TYPES, LIGHTSABER_WEAPON_TYPES, SIMPLE_WEAPON_TYPES, weaponGroup } from "../common/constants.mjs";
 
 
 function getCrewPosition(equipmentSlot) {
@@ -111,14 +112,28 @@ export function getPossibleProficiencies(actor, weapon) {
     return descriptors.filter(descriptor => !!descriptor);
 }
 
-const RANGED_WEAPON_TYPES = ["pistols", "rifles", "exotic ranged weapons", "ranged weapons", "grenades",
-    "heavy weapons", "simple ranged weapons"];
-const LIGHTSABER_WEAPON_TYPES = ["lightsabers", "lightsaber"];
-const SIMPLE_WEAPON_TYPES = ['simple melee weapons', 'simple ranged weapons', 'simple melee weapon', 'simple ranged weapon', "grenades"];
-const UNARMED_WEAPON_TYPES = ["simple melee weapon"];
+/**
+ *
+ * @param weapon {SWSEItem}
+ * @returns {boolean}
+ */
+export function isRanged(weapon) {
+    let itemData = weapon.system;
+    return RANGED_WEAPON_TYPES.includes(itemData.subtype.toLowerCase());
+}
 
-function isRanged(weapon) {
-    return RANGED_WEAPON_TYPES.includes(weapon.data.data.subtype.toLowerCase());
+/**
+ *
+ * @param weapon {SWSEItem}
+ * @returns {boolean}
+ */
+export function isMelee(weapon) {
+    let itemData = weapon.system;
+    let subtype = itemData.subtype;
+    if (!subtype && weapon.type === 'beastAttack') {
+        subtype = "Melee Natural Weapons"
+    }
+    return weaponGroup['Melee Weapons'].includes(subtype);
 }
 
 /**

--- a/module/actor/attack.mjs
+++ b/module/actor/attack.mjs
@@ -1,10 +1,11 @@
 import {UnarmedAttack} from "./unarmed-attack.mjs";
 import {getInheritableAttribute} from "../attribute-helper.mjs";
-import {LIGHTSABER_WEAPON_TYPES, weaponGroup} from "../common/constants.mjs";
 import {compareSizes, getSize} from "./size.mjs";
 import {
     canFinesse,
     isLightsaber,
+    isRanged,
+    isMelee,
     getFocusAttackBonuses,
     getPossibleProficiencies,
     getProficiencyBonus,
@@ -191,55 +192,6 @@ export class Attack {
         return modifiers;
     }
 
-    /**
-     *
-     * @param item {SWSEItem}
-     * @returns {boolean}
-     */
-    isRanged(item) {
-        let data = item.system;
-        return weaponGroup['Ranged Weapons'].includes(data.subtype);
-    }
-
-    /**
-     *
-     * @param item {SWSEItem}
-     * @returns {boolean}
-     */
-    isMelee(item) {
-        let data = item.system;
-        let subtype = data.subtype;
-        if (!subtype && item.type === 'beastAttack') {
-            subtype = "Melee Natural Weapons"
-        }
-        return weaponGroup['Melee Weapons'].includes(subtype);
-    }
-
-    /**
-     *
-     * @param actor {SWSEActor}
-     * @param item {SWSEItem}
-     * @returns {boolean|boolean}
-     */
-    canFinesse(actor, item) {
-        let sizes = compareSizes(actor.size, item.size);
-        let isOneHanded = sizes < 1;
-        let isLight = sizes < 0;
-        let weaponTypes = getPossibleProficiencies(actor, item);
-
-        return isLight || (isOneHanded && isFocus(actor, weaponTypes)) || this.isLightsaber(item);
-    }
-
-    /**
-     *
-     * @param weapon {SWSEItem}
-     * @returns {boolean}
-     */
-    isLightsaber(weapon) {
-        return LIGHTSABER_WEAPON_TYPES.includes(weapon.data.data.subtype.toLowerCase());
-    }
-
-
     get name() {
         let name = this.item.name;
         return ((this.isUnarmed && 'Unarmed Attack' !== name) ? `Unarmed Attack (${name})` : name) + this.nameModifier;
@@ -329,7 +281,7 @@ export class Attack {
 
     _resolveAttributeModifier(item, actor, weaponTypes) {
         let attributeStats = []
-        if (this.isRanged(item)) {
+        if (isRanged(item)) {
             attributeStats.push("DEX")
         } else {
             attributeStats.push("STR")
@@ -401,7 +353,7 @@ export class Attack {
             terms.push(...appendTerms(mod.value, mod.source))
         }
 
-        if (this.isMelee(item)) {
+        if (isMelee(item)) {
             let abilityMod = parseInt(actor.system.attributes.str.mod);
             let isTwoHanded = compareSizes(getSize(actor), getSize(item)) === 1;
             let isMySize = compareSizes(getSize(actor), getSize(item)) === 0;
@@ -705,7 +657,7 @@ export class Attack {
 
     getDynamicModes(existingDynamicModes) {
         let dynamics = [];
-        if (this.isMelee(this.item)) {
+        if (isMelee(this.item)) {
             const actor = this.actor;
             let isMySize = compareSizes(getSize(actor), getSize(this.item)) === 0;
             let cannotUseTwoHands = getInheritableAttribute({entity:this.item, attributeKey:"isLightWeapon", reduce: "OR"})

--- a/module/actor/attack.mjs
+++ b/module/actor/attack.mjs
@@ -4,6 +4,7 @@ import {LIGHTSABER_WEAPON_TYPES, weaponGroup} from "../common/constants.mjs";
 import {compareSizes, getSize} from "./size.mjs";
 import {
     canFinesse,
+    isLightsaber,
     getFocusAttackBonuses,
     getPossibleProficiencies,
     getProficiencyBonus,
@@ -401,7 +402,7 @@ export class Attack {
         }
 
         if (this.isMelee(item)) {
-            let strMod = parseInt(actor.system.attributes.str.mod);
+            let abilityMod = parseInt(actor.system.attributes.str.mod);
             let isTwoHanded = compareSizes(getSize(actor), getSize(item)) === 1;
             let isMySize = compareSizes(getSize(actor), getSize(item)) === 0;
 
@@ -417,7 +418,21 @@ export class Attack {
                 }
             }
 
-            terms.push(...appendNumericTerm(isTwoHanded ? strMod * 2 : strMod, "Attribute Modifier"))
+            if(isLightsaber(item))
+            {
+                let abilitySelect = getInheritableAttribute({
+                    entity: actor,
+                    attributeKey: "lightsabersDamageStat",
+                    reduce: "VALUES"
+                })[0].toLowerCase();
+                const abilities = ["str", "dex", "con", "int", "wis", "cha"];
+                if (abilities.includes(abilitySelect)) {
+                    let replaceAbilityMod = parseInt(actor.system.attributes[`${abilitySelect}`].mod);
+                    abilityMod = replaceAbilityMod > abilityMod ? replaceAbilityMod: abilityMod;
+                }
+            }
+
+            terms.push(...appendNumericTerm(isTwoHanded ? abilityMod * 2 : abilityMod, "Attribute Modifier"))
         }
 
         let weaponTypes = getPossibleProficiencies(actor, item);

--- a/module/common/constants.mjs
+++ b/module/common/constants.mjs
@@ -61,8 +61,7 @@ export const equipableTypes = ["armor", "weapon", "equipment", "upgrade", "trait
 export const LIMITED_TO_ONE_TYPES = ["feat", "talent"]
 
 
-export const RANGED_WEAPON_TYPES = ["pistols", "rifles", "exotic ranged weapons", "ranged weapons", "grenades",
-    "heavy weapons", "simple ranged weapons"];
+export const RANGED_WEAPON_TYPES = ["pistols", "rifles", "exotic ranged weapons", "ranged weapons", "grenades", "heavy weapons", "simple ranged weapons"];
 export const LIGHTSABER_WEAPON_TYPES = ["lightsabers", "lightsaber"];
 export const SIMPLE_WEAPON_TYPES = ['simple melee weapons', 'simple ranged weapons', 'simple melee weapon', 'simple ranged weapon', "grenades"];
 

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -504,7 +504,7 @@ export class SWSEItem extends Item {
     }
 
     static getItemSize(swseItem) {
-        let size = swseItem.data?.size || swseItem.data?.data?.size
+        let size = swseItem.system?.size || swseItem.data?.size || swseItem.data?.data?.size
         if (SWSEItem.getItemStripping(swseItem, "makeColossal")?.value) {
             size = changeSize(size, 1)
         }


### PR DESCRIPTION
There was no existing handling of lightsabersDamageStat gained from the Ataru lightsaber form talent

Several functions within attack.mjs and attack-handler.mjs were overlapping/redundant.