### PR TITLE
update roll resolution to use Foundry Die

### DIFF
--- a/module/actor/attack.mjs
+++ b/module/actor/attack.mjs
@@ -1357,17 +1357,17 @@ function test(){
         `,{"class":"NumericTerm","options":{"flavor":"bonus"},"evaluated":false,"number":2}]`, JSON.stringify(appendTerms("-2", "bonus")))
 
     assertEquals(`[{"class":"OperatorTerm","options":{},"evaluated":false,"operator":"-"}`+
-        `,{"class":"DiceTerm","options":{"flavor":"bonus"},"evaluated":false,"number":4,"faces":10,"modifiers":[],"results":[]}]`, JSON.stringify(appendTerms("-4d10", "bonus")))
+        `,{"class":"Die","options":{"flavor":"bonus"},"evaluated":false,"number":4,"faces":10,"modifiers":[],"results":[]}]`, JSON.stringify(appendTerms("-4d10", "bonus")))
 
     assertEquals(`[{"class":"OperatorTerm","options":{},"evaluated":false,"operator":"-"}`+
-        `,{"class":"DiceTerm","options":{"flavor":"bonus"},"evaluated":false,"number":4,"faces":10,"modifiers":[],"results":[]}`+
+        `,{"class":"Die","options":{"flavor":"bonus"},"evaluated":false,"number":4,"faces":10,"modifiers":[],"results":[]}`+
         `,{"class":"OperatorTerm","options":{},"evaluated":false,"operator":"-"},`+
-        `{"class":"DiceTerm","options":{"flavor":"bonus"},"evaluated":false,"number":6,"faces":4,"modifiers":[],"results":[]},`+
+        `{"class":"Die","options":{"flavor":"bonus"},"evaluated":false,"number":6,"faces":4,"modifiers":[],"results":[]},`+
         `{"class":"OperatorTerm","options":{},"evaluated":false,"operator":"+"},`+
         `{"class":"NumericTerm","options":{"flavor":"bonus"},"evaluated":false,"number":9}]`, JSON.stringify(appendTerms("-4d10-6d4+9", "bonus")))
 
     assertEquals(`[{"class":"OperatorTerm","options":{},"evaluated":false,"operator":"+"}`+
         `,{"class":"NumericTerm","options":{"flavor":"bomb"},"evaluated":false,"number":1}`+
         `,{"class":"OperatorTerm","options":{},"evaluated":false,"operator":"+"}`+
-        `,{"class":"DiceTerm","options":{"flavor":"bomb"},"evaluated":false,"number":3,"faces":6,"modifiers":[],"results":[]}]`, JSON.stringify(appendTerms("1+3d6", "bomb")))
+        `,{"class":"Die","options":{"flavor":"bomb"},"evaluated":false,"number":3,"faces":6,"modifiers":[],"results":[]}]`, JSON.stringify(appendTerms("1+3d6", "bomb")))
 }

--- a/module/common/util.mjs
+++ b/module/common/util.mjs
@@ -1647,10 +1647,10 @@ export function appendTerm(value, flavor) {
     if (`${parseInt(value)}` === value) {
         return appendNumericTerm(value, flavor);
     }
-    return appendDiceTerm(value, flavor)
+    return appendDieTerm(value, flavor)
 }
 
-export function appendDiceTerm(value, flavor) {
+export function appendDieTerm(value, flavor) {
     if (!value) {
         return [];
     }
@@ -1662,7 +1662,7 @@ export function appendDiceTerm(value, flavor) {
         return [];
     }
     return [number > -1 ? plus() : minus(),
-        new DiceTerm({number: Math.abs(number), faces, options: getDieFlavor(flavor)})];
+        new Die({number: Math.abs(number), faces, options: getDieFlavor(flavor)})];
 }
 
 export function appendNumericTerm(value, flavor) {


### PR DESCRIPTION
Fixes #386 

Foundry DiceTerm does not inherently have a DENOMINATION set for 'd' (Dice). Changed to use the foundry Die extended class.

This allows Dice so nice to play nice with the rolls. ;p