### PR TITLE
Populating cost attribute for Item Piles module

### DIFF
--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1499,6 +1499,13 @@ export class SWSEItem extends Item {
             }
         };
     }
+
+    toObject() {
+        let o = super.toObject();
+        let cost = this.system.changes.filter(c => c.key === "cost");
+        o.system.cost = (cost) ? cost[0]["value"] : "0";
+        return o;
+    }
 }
 
 export function reduceWeaponRange(range) {

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1502,8 +1502,8 @@ export class SWSEItem extends Item {
 
     toObject() {
         let o = super.toObject();
-        let cost = this.system.changes.filter(c => c.key === "cost");
-        o.system.cost = (cost) ? cost[0]["value"] : "0";
+        let cost = this.system.changes.find(c => c.key === "cost");
+        o.system.cost = (cost) ? cost["value"] : "0";
         return o;
     }
 }


### PR DESCRIPTION
This closes #435. Overwrote `toObject` method to include item cost since that is what Item Piles module uses to determine cost.

Initially attempted to add a getter to `system.cost`, but that didn't work because Item Piles uses `toObject` first. Since there is no constructor, the best placed I figured I could put the `cost` getter would be in `prepareData`, but there were cases where you could have an item in an Item Pile without triggering `prepareData` so rather than using a getter, I just put the getter logic inside the `toObject` override method.